### PR TITLE
Mark II vocabulary changes on fuzz post

### DIFF
--- a/_posts/2025-12-12-fuzz.md
+++ b/_posts/2025-12-12-fuzz.md
@@ -8,21 +8,21 @@ date: 2025-12-12
 
 ## Abstract
 
-We propose a permissionless patronage protocol. An author shares his work, his authorship. A patron shares value, patronage back through a Fuzz client. The patronage is recorded and can be verified in a trust-minimized way. The cost for both the patron and the author to switch between Fuzz clients is zero.
+We propose a permissionless patronage protocol. An author publishes his work, his authorship. A patron publishes value, his patronage, back through a Fuzz client. The patronage is recorded and can be verified in a trust-minimized way. The cost for both the patron and the author to switch between Fuzz clients is zero.
 
 ---
 
 ## Problem
 
-Sharing ideas is frictionless. But we have built systems that treat ideas as physical objects.
+Sharing ideas is frictionless. Yet we have built systems that treat ideas as physical objects.
 
-Physical objects are scarce. If I take Pythagoras's chair, he cannot use it. Ideas are not scarce.[1] If I use the Pythagorean theorem, Pythagoras can still use it. Digital media is closer to ideas than to physical objects. Copying is frictionless, and the copy does not diminish the original.
+Physical objects are scarce. If one takes Pythagoras's chair, he cannot use it. Ideas are not scarce.[1] If one uses the Pythagorean theorem, Pythagoras can still use it. Digital media is closer to ideas than to physical objects, copying is frictionless, and the copy does not diminish the original.
 
-Different communities have different norms about sharing. Academic communities share freely with attribution, music communities have complex traditions around sampling and covers, and software communities have varied licenses from proprietary to public domain. No central authority knows all these norms[2], and no single rule can govern all domains.
+Communities differ on what sharing means. Academics share freely with attribution; musicians sample, cover, and quote within complex traditions; software developers license their work from proprietary to public domain. No central authority knows all these norms[2], and no single rule can govern all domains.
 
-A protocol cannot decide these norms. It can only provide infrastructure for value to flow back to creators, and let communities govern themselves.
+A protocol cannot decide these norms. It can only provide infrastructure for value to flow back to authors, and let communities govern themselves.
 
-The current system creates value by restricting ideas. We need a system where value flows back to creators without restricting how their work is shared, copied, or modified.
+The current system creates value by restricting ideas. We need a system where value flows back to authors without restricting how their work is shared, copied, or modified.
 
 ---
 
@@ -30,25 +30,25 @@ The current system creates value by restricting ideas. We need a system where va
 
 Three players: an author, a patron, and a Fuzz client.
 
-An author publishes and shares a work and authorship. The author includes an address where value can be sent. Anyone can send value directly. But most patrons will interact through a Fuzz client.
+An author publishes his work, his authorship. The authorship event includes an address where value can be sent. Anyone can send value directly, though most patrons will interact through a Fuzz client.
 
-A patron publishes and shares value and patronage. The patron experiences the work and is willing to contribute to the author. But why contribute if the work is already free?
+A patron publishes value, his patronage. He experiences the work and wants to patronize the author. But why patronize if the work is already free?
 
-A Fuzz client lets patrons discover and experience works. The Fuzz client creates an economy around the experience. This can be subscriptions, advertisements, pay-what-you-want, or any model the Fuzz client invents. The protocol does not dictate the economy, it only creates the rules, and then, the market finds what works.
+A Fuzz client lets patrons discover and experience works, and builds an economy around that experience: subscriptions, advertisements, pay-what-you-want, or any model the client invents. The protocol does not dictate the economy; it sets the rules.
 
-When value flows through the Fuzz client to the author, it is attributed to the patron. The patron builds a patronage history that lives outside any Fuzz client's control. The history is portable and verifiable.
+When value flows through the Fuzz client to the author, it is attributed to the patron, who builds a patronage history that lives outside any client's control, portable, verifiable.
 
 Fuzz changes the incentives.
 
-An author can see their top patrons. The author can reward top patrons with early access, exclusive works, or recognition. This makes patronage history valuable to patrons.
+An author can see his top patrons. He can reward them with early access, exclusive works, or recognition. Patronage history becomes valuable.
 
-A patron who values their patronage history uses a Fuzz client that sends more to authors. If the client keeps too much, it diminishes the patron's recorded patronage. Since the patron can verify how much each client passes through, they choose to leave for a better one.
+A patron who values his patronage history uses a Fuzz client that sends more to authors. If the client keeps too much, it diminishes the recorded patronage, and since the patron can verify how much each client passes through, he leaves for a better one.
 
-A client that sends little to authors loses patrons to one that sends more. The cost of switching is zero, patrons take their history with them, and good services compete on value, not on lock-in.
+A client that sends little to authors loses patrons to one that sends more. The cost of switching is zero, patrons take their history with them, and clients compete on what they pass through.
 
-An author receives value from patrons regardless of which Fuzz client they use. The author does not depend on any single Fuzz client. The author's audience is not locked in.
+An author receives value from patrons regardless of which Fuzz client they use, he does not depend on any single client, and his audience is not locked in.
 
-Each player does what benefits them. The better the work, the more patrons. The better the Fuzz client's economy, the more patrons. And patrons who contribute more rank higher with authors. Everyone checks everyone. Trust requirements are minimized.[3]
+Each player acts on his own incentive. The better the work, the more patrons. The better the Fuzz client's economy, the more patrons. Patrons who patronize more rank higher with authors. Everyone checks everyone, and trust is minimized.[3]
 
 ---
 
@@ -56,7 +56,7 @@ Each player does what benefits them. The better the work, the more patrons. The 
 
 ### What is a Fuzz Client
 
-A Fuzz client connects authors and patrons. More concretely, it is a Nostr client that connects to relays, fetches authorship events, displays works to patrons, and publishes patronage events. It also runs an economy, curates works, and provides discovery.
+A Fuzz client connects authors and patrons, or more precisely it is a Nostr client that connects to relays, fetches authorship events, displays works to patrons, and may publish patronage events. It also runs an economy, curates works, and provides discovery.
 
 Fuzz clients let authors upload works, organize them, and track how they perform. The author publishes an authorship event, a Nostr event containing the work's hash, a URL to retrieve it, metadata, and an address for receiving value.
 
@@ -64,13 +64,13 @@ Fuzz clients let patrons browse, search, follow authors, and experience works. W
 
 The Fuzz client connects several components:
 
-**Relay connection.** Authorship events and patronage events flow through Nostr relays.
+**Relay connection.** Authorship events and patronage events flow through Nostr relays. Fuzz clients SHOULD respect NIP-65 relay metadata when fetching authorship events for a given author.
 
 **Work storage.** Works are stored on Blossom servers, addressed by hash. The author can self-host or use third-party servers. The Fuzz client can mirror works for redundancy.
 
 **Client interface.** The application that authors and patrons interact with. Web app, mobile app, desktop app, or any interface.
 
-**Curation.** Fuzz clients select, organize, recommend, and exclude. Different communities have different standards.
+**Curation.** Fuzz clients select, organize, and exclude according to whatever standard their community holds.
 
 **Economy.** The Fuzz client runs an economy. This is how value flows from patrons to authors:
 
@@ -78,13 +78,13 @@ The Fuzz client connects several components:
 - Attention converted to value and attributed to the patron
 - Pay-what-you-want where patrons choose amounts
 - Pay-per-piece where each work has a price
-- Any combination or innovation
+- Any mix the client invents
 
 The protocol does not prefer one economy over another. It creates the rules. The market finds what works.
 
 A minimal Fuzz client connects to public relays, proxies works from author servers, and publishes patronage events. A full-featured one runs its own relay, hosts works on its own Blossom server, and builds sophisticated economy models.
 
-Fuzz clients can specialize. Some might only serve authors, supporting the publishing of authorship events. Others might only serve patrons, supporting discovery and patronage. The patronage event is agnostic of the work; it centers on the author, not the work.
+Fuzz clients can specialize. Some serve only authors, helping them publish authorship events. Others serve only patrons, helping with discovery and patronage. The patronage event is agnostic of the work, it centers on the author.
 
 ### Proof of Patronage
 
@@ -98,9 +98,9 @@ OP_RETURN: FUZZ<patron's 32-byte Nostr pubkey>
 
 The prefix "FUZZ" (4 bytes) identifies the protocol. The patron's raw public key (32 bytes) attributes the patronage. Total: 36 bytes.
 
-The author's address is already the recipient. The patron's pubkey in the OP_RETURN answers the question: who gets credit for this patronage?
+The author's address is the recipient of Output 1. The patron's pubkey in the OP_RETURN says who gets credit.
 
-The transaction can come from any wallet. The source address does not matter. What matters is the OP_RETURN. This decouples the payment source from the attribution. A Fuzz client can generate value through any economy and attribute it to patrons.
+The transaction can come from any wallet, the source address does not matter, only the OP_RETURN. This decouples the payment source from the attribution: the Fuzz client can generate value through any economy and attribute it to the patron.
 
 The Fuzz client manages the economy. The blockchain records the patronage. The patron owns the proof.
 
@@ -118,35 +118,37 @@ Anyone can run this query. The data is public. The proof is the chain.
 
 **Patron verification:**
 
-When an author offers access to top patrons, the patron proves they own the pubkey. Any Nostr event signed by that pubkey proves ownership. The blockchain proves patronage. Two public systems. One proves identity. One proves patronage.
+When an author offers access to top patrons, the patron proves he owns the pubkey. Any Nostr event signed by that pubkey proves ownership. The blockchain proves patronage. Two public systems: one to prove identity and one to prove patronage.
 
 ### Limitations
 
-On-chain transactions are expensive for small amounts. If the transaction fee exceeds the contribution itself, the economics break. This limits the protocol to contributions above a certain threshold.
+On-chain transactions are expensive for small amounts, if the fee exceeds the patronage the economics break, which limits the protocol to patronage above some floor.
 
-Cheaper approaches exist. Lightning reduces costs dramatically.[4] Batching multiple patrons into one transaction would reduce costs. These optimizations require additional infrastructure and design work that are outside the scope of this proposal.
+Cheaper approaches exist. Lightning settles small payments off-chain at negligible cost.[4] Batching multiple patrons into one transaction reduces fees further. Both want infrastructure and design that fall outside this proposal.
 
 This document specifies on-chain settlement as the primitive. Future iterations can build on this foundation.
 
 ### Media Distribution
 
-Authors upload their work to a Blossom server. Blossom is a protocol for storing binary data addressed by SHA-256 hash. The author receives a URL containing the hash. This hash is permanent. Anyone with the hash can retrieve the work from any Blossom server that has it.
+Authors upload their work to a Blossom server, a protocol for storing binary data addressed by SHA-256 hash. The author receives a URL containing the hash, the hash is permanent, and anyone holding it can retrieve the work from any Blossom server that has it.
 
 The author then publishes a Nostr event with:
 - The hash of the work
 - A URL to retrieve it
-- Metadata (title, description, type)
+- Metadata (title, description)
 - An address for receiving value
 
-The authorship event is a Nostr event. The work is stored on Blossom. The authorship event lives on relays. This distinction matters: authorship events on relays can be queried by kind, discovered through social graphs, and indexed by any client. Nostr events enable discovery. Fuzz clients solve curation.
+The `url` tag is a retrieval hint; clients SHOULD fall back to the author's BUD-03 user-server-list (`kind:10063`) if the URL is unreachable, verifying retrieved bytes against the `x` tag SHA-256 hash.
 
-The author can self-host their Blossom server on their own machine. The author can use a third-party Blossom server. The author can use multiple servers for redundancy. The choice is theirs. The author does not depend on any Fuzz client to host their work.
+The authorship event is a Nostr event living on relays, the work itself is stored on Blossom. Events on relays can be queried by kind, discovered through social graphs, and indexed by any Nostr client. Nostr events enable discovery. Fuzz clients solve curation.
 
-A Fuzz client can mirror works using Blossom's mirroring protocol. This creates redundancy and improves performance. If the original server becomes unavailable, the mirrored copy remains accessible. The hash ensures integrity. The work is the same regardless of which server delivers it.
+The author can self-host on his own machine, use a third-party Blossom server, or run several for redundancy, the choice is his. He does not depend on any Fuzz client to host his work.
 
-A note on author identity: This protocol requires a public key for each author. If someone creates a work but has no Nostr identity, another party could publish the authorship event on their behalf and list their address. The term "author" refers to whoever publishes the authorship event and controls the address.
+A Fuzz client can mirror works through Blossom's mirroring protocol, which adds redundancy and improves performance. If the original server goes down, the mirrored copy remains accessible, the hash guarantees integrity, the work is the same whichever server delivers it.
 
-The protocol assumes authors share works without restriction. An author who publishes an authorship event is declaring their work can be freely shared, copied, and distributed.
+A note on identity. The protocol requires a public key for each author, so if someone creates a work without a Nostr identity, another party can publish the authorship event on his behalf and list his address. The term "author" means whoever publishes the event and controls the address.
+
+The protocol assumes authors share their work freely. Publishing an authorship event declares the work open to copy and to redistribution.
 
 ---
 
@@ -154,33 +156,35 @@ The protocol assumes authors share works without restriction. An author who publ
 
 ### Patron Switching
 
-A patron's value is their patronage history. This history must not be locked in a Fuzz client's database.
+A patron's stake is his patronage history, which must not be locked inside any Fuzz client's database.
 
-Patronage is recorded on the blockchain. Any client can query for transactions to an author's address and parse the OP_RETURN for patron pubkeys. The patron's history is the aggregation of these transactions across all Fuzz clients.
+Patronage is recorded on the blockchain, and anyone can query an author's address and parse the OP_RETURN for patron pubkeys. The patron's history is the aggregation across all Fuzz clients.
 
 When a patron switches Fuzz clients:
-1. Their identity (keypair) is theirs
-2. Their history is on the blockchain
+1. His identity (keypair) is his
+2. His history is on the blockchain
 3. The new Fuzz client can query for existing history
 4. There is nothing to export or migrate
 
-A Fuzz client cannot lock in a patron's history because it does not control the blockchain. Transactions are permanent. The proof persists.
+A Fuzz client cannot lock in a patron's history because it does not control the blockchain. Transactions are permanent.
 
 The cost of switching Fuzz clients is zero.
 
 ### Author Independence
 
-An author's work should not depend on any single Fuzz client.
+No author's work should depend on a single Fuzz client.
 
-The work itself is stored on Blossom servers. The author can run their own server on their own machine. The author can use multiple servers. The hash-based addressing means the work is retrievable from any server that has it.
+The work itself sits on Blossom servers. The author can host his own on his own machine, or use several, the hash-based addressing makes the work retrievable from any server that has it.
 
-The author's address for receiving value is theirs. It is not controlled by any Fuzz client. Patrons can send value directly if they choose.
+The author's address for receiving value is his, not controlled by any Fuzz client, and patrons can send directly when they choose.
 
-The author's events are on relays. Any Fuzz client can read them. The author is not exclusive to any Fuzz client.
+His events live on relays, any Fuzz client can read them, and he is not exclusive to any one.
 
 ---
 
 ## Events
+
+In the schemas below, `<...>` denotes a placeholder for the actual value.
 
 ### Authorship Event (Kind 31339)
 
@@ -194,7 +198,7 @@ The author's events are on relays. Any Fuzz client can read them. The author is 
     ["d", "<unique identifier>"],
     ["title", "<title of work>"],
     ["x", "<SHA-256 hash>"],
-    ["url", "https://blossom.server/<sha256>.<ext>"],
+    ["url", "https://blossom.server/<sha256>"],
     ["address", "<bitcoin address>"]
   ]
 }
@@ -204,27 +208,26 @@ The `address` tag contains the author's Bitcoin address for receiving patronage.
 
 Kind 31339 is an addressable event. The `d` tag makes it addressable and updatable.
 
-### Patronage Event (Kind 32500)
+### Patronage Event (Kind 9740)
 
 ```json
 {
-  "kind": 32500,
+  "kind": 9740,
   "pubkey": "<Fuzz client pubkey>",
   "created_at": 1234567890,
   "content": "",
   "tags": [
-    ["d", "<txid>"],
     ["p", "<author pubkey>"],
-    ["c", "<patron pubkey>"],
-    ["amount", "<satoshis>"],
+    ["P", "<patron pubkey>"],
+    ["amount", "<integer satoshis>", "sat"],
     ["txid", "<bitcoin transaction id>"]
   ]
 }
 ```
 
-The `c` tag denotes the patron.
+The `P` tag denotes the patron, following NIP-57 convention (lowercase `p` for the recipient of value, uppercase `P` for the sender).
 
-This event is optional. The blockchain is the source of truth. This event provides convenience: it helps clients discover patronage without querying the blockchain directly. The txid allows verification.
+This event is optional. The blockchain is the source of truth. The event provides convenience: it helps clients discover patronage without querying the blockchain directly. The txid allows verification.
 
 ---
 
@@ -240,13 +243,13 @@ This event is optional. The blockchain is the source of truth. This event provid
 
 ## Conclusion
 
-An author shares his work, his authorship. A patron shares value, patronage back through a Fuzz client. The patronage is recorded on the blockchain. The patron's history is portable. The author receives value. The cost of switching is zero.
+An author publishes his work, his authorship. A patron publishes value, his patronage, back through a Fuzz client. The patronage is recorded on the blockchain, the patron's history is portable, the author receives value, the cost of switching is zero.
 
-The protocol does not dictate which economy works. It provides infrastructure for value to flow back to creators, with proof, and lets the market decide the rest.
+The protocol does not dictate which economy works. It provides infrastructure for value to flow back to authors, with proof, and leaves the rest to whatever the communities settle on.
 
 On-chain transactions are expensive for small amounts. Cheaper approaches exist but require additional design work.
 
-Derivative works are not yet addressed. A remix references the original. A cover version credits the songwriter. I'll address derivative attribution in a follow-up.
+Derivative works are not yet addressed: a remix references the original, a cover credits the songwriter. We will address derivative attribution in a follow-up.
 
 ---
 

--- a/_posts/2025-12-12-fuzz.md
+++ b/_posts/2025-12-12-fuzz.md
@@ -32,7 +32,7 @@ Three players: an author, a patron, and a Fuzz client.
 
 An author publishes his work, his authorship. The authorship event includes a Bitcoin address for receiving value. Anyone can pay the author directly, though most patrons will interact through a Fuzz client.
 
-A patron sends value, his patronage. He experiences the work and wants to contribute to the author. But why contribute if the work is already free?
+A patron sends value, his patronage. He experiences the work and wants to send patronage to the author. But why send patronage if the work is already free?
 
 A Fuzz client lets patrons discover and experience works, and builds an economy around that experience: subscriptions, advertisements, pay-what-you-want, or any model the client invents. The protocol sets the rules, not the economy.
 
@@ -46,7 +46,7 @@ A client that sends little to authors loses patrons to one that sends more. The 
 
 An author receives value from patrons regardless of which Fuzz client they use. He depends on no single client, and his audience is not locked in.
 
-Each player acts on his own incentive. The better the work, the more patrons. The better the Fuzz client's economy, the more patrons. Patrons who contribute more rank higher with authors. Everyone checks everyone, and trust is minimized.[3]
+Each player acts on his own incentive. The better the work, the more patrons. The better the Fuzz client's economy, the more patrons. Patrons with more patronage rank higher with authors. Everyone checks everyone, and trust is minimized.[3]
 
 ---
 
@@ -120,7 +120,7 @@ When an author offers access to top patrons, the patron proves he owns the pubke
 
 ### Limitations
 
-On-chain transactions are expensive for small amounts. If the fee exceeds the contribution, the economics break, and the protocol is limited to contributions above some floor.
+On-chain transactions are expensive for small amounts. If the fee exceeds the patronage, the economics break, and the protocol is limited to patronage above some floor.
 
 Cheaper approaches exist. Lightning settles small payments off-chain at negligible cost.[4] Batching multiple patrons into one transaction reduces fees further. Both require infrastructure and design that fall outside this proposal.
 

--- a/_posts/2025-12-12-fuzz.md
+++ b/_posts/2025-12-12-fuzz.md
@@ -8,7 +8,7 @@ date: 2025-12-12
 
 ## Abstract
 
-We propose a permissionless patronage protocol. An author publishes and shares a work and authorship. A patron publishes and shares value and patronage through a Fuzz client. The patronage is recorded and can be verified in a trust-minimized way. The cost for both the patron and the author to switch between Fuzz clients is zero.
+We propose a permissionless patronage protocol. An author shares his work, his authorship. A patron shares value, patronage back through a Fuzz client. The patronage is recorded and can be verified in a trust-minimized way. The cost for both the patron and the author to switch between Fuzz clients is zero.
 
 ---
 
@@ -32,7 +32,7 @@ Three players: an author, a patron, and a Fuzz client.
 
 An author publishes and shares a work and authorship. The author includes an address where value can be sent. Anyone can send value directly. But most patrons will interact through a Fuzz client.
 
-A patron publishes and shares value and patronage. The patron experiences the work and is willing to support the author. But why support if the work is already free?
+A patron publishes and shares value and patronage. The patron experiences the work and is willing to contribute to the author. But why contribute if the work is already free?
 
 A Fuzz client lets patrons discover and experience works. The Fuzz client creates an economy around the experience. This can be subscriptions, advertisements, pay-what-you-want, or any model the Fuzz client invents. The protocol does not dictate the economy, it only creates the rules, and then, the market finds what works.
 
@@ -42,9 +42,9 @@ Fuzz changes the incentives.
 
 An author can see their top patrons. The author can reward top patrons with early access, exclusive works, or recognition. This makes patronage history valuable to patrons.
 
-A patron who values their patronage history uses a Fuzz client that sends more to authors. A Fuzz client that keeps too much diminishes the patron's recorded patronage. Since the patron can verify how much each Fuzz client passes through, they choose to leave for a better Fuzz client.
+A patron who values their patronage history uses a Fuzz client that sends more to authors. If the client keeps too much, it diminishes the patron's recorded patronage. Since the patron can verify how much each client passes through, they choose to leave for a better one.
 
-A Fuzz client that sends little to authors loses patrons to one that sends more. The cost of switching is zero, patrons take their history with them, and good services compete on value, not on lock-in.
+A client that sends little to authors loses patrons to one that sends more. The cost of switching is zero, patrons take their history with them, and good services compete on value, not on lock-in.
 
 An author receives value from patrons regardless of which Fuzz client they use. The author does not depend on any single Fuzz client. The author's audience is not locked in.
 
@@ -56,13 +56,13 @@ Each player does what benefits them. The better the work, the more patrons. The 
 
 ### What is a Fuzz Client
 
-A Fuzz client connects authors and patrons. More concretely, it is a Nostr client that connects to relays, fetches authorship events, displays works to patrons, and publishes patronage events. A Fuzz client also runs an economy, curates works, and provides discovery.
+A Fuzz client connects authors and patrons. More concretely, it is a Nostr client that connects to relays, fetches authorship events, displays works to patrons, and publishes patronage events. It also runs an economy, curates works, and provides discovery.
 
-A Fuzz client lets authors upload works, organize them, and track how they perform. The author publishes an authorship event, a Nostr event containing the work's hash, a URL to retrieve it, metadata, and an address for receiving value.
+Fuzz clients let authors upload works, organize them, and track how they perform. The author publishes an authorship event, a Nostr event containing the work's hash, a URL to retrieve it, metadata, and an address for receiving value.
 
-A Fuzz client lets patrons browse, search, follow authors, and experience works. When value flows to an author, the Fuzz client publishes a patronage event, a Nostr event recording the patron, the author, and the amount.
+Fuzz clients let patrons browse, search, follow authors, and experience works. When value flows to an author, the client publishes a patronage event, a Nostr event recording the patron, the author, and the amount.
 
-A Fuzz client connects several components:
+The Fuzz client connects several components:
 
 **Relay connection.** Authorship events and patronage events flow through Nostr relays.
 
@@ -82,9 +82,9 @@ A Fuzz client connects several components:
 
 The protocol does not prefer one economy over another. It creates the rules. The market finds what works.
 
-A minimal Fuzz client connects to public relays, proxies works from author servers, and publishes patronage events. A full-featured Fuzz client runs its own relay, hosts works on its own Blossom server, and builds sophisticated economy models.
+A minimal Fuzz client connects to public relays, proxies works from author servers, and publishes patronage events. A full-featured one runs its own relay, hosts works on its own Blossom server, and builds sophisticated economy models.
 
-A Fuzz client can specialize. Some Fuzz clients might only serve authors, supporting the publishing of authorship events. Some might only serve patrons, supporting discovery and patronage. The patronage event is agnostic of the work; it centers on the author, not the work.
+Fuzz clients can specialize. Some might only serve authors, supporting the publishing of authorship events. Others might only serve patrons, supporting discovery and patronage. The patronage event is agnostic of the work; it centers on the author, not the work.
 
 ### Proof of Patronage
 
@@ -96,7 +96,7 @@ Output 1: Payment to author's Bitcoin address
 OP_RETURN: FUZZ<patron's 32-byte Nostr pubkey>
 ```
 
-The prefix "FUZZ" (4 bytes) identifies the protocol. The patron's raw public key (32 bytes) identifies who gets credit for the patronage. Total: 36 bytes.
+The prefix "FUZZ" (4 bytes) identifies the protocol. The patron's raw public key (32 bytes) attributes the patronage. Total: 36 bytes.
 
 The author's address is already the recipient. The patron's pubkey in the OP_RETURN answers the question: who gets credit for this patronage?
 
@@ -164,7 +164,7 @@ When a patron switches Fuzz clients:
 3. The new Fuzz client can query for existing history
 4. There is nothing to export or migrate
 
-A Fuzz client cannot lock in a patron's history because the Fuzz client does not control the blockchain. Transactions are permanent. The proof persists.
+A Fuzz client cannot lock in a patron's history because it does not control the blockchain. Transactions are permanent. The proof persists.
 
 The cost of switching Fuzz clients is zero.
 
@@ -240,7 +240,7 @@ This event is optional. The blockchain is the source of truth. This event provid
 
 ## Conclusion
 
-An author publishes and shares a work and authorship. A patron publishes and shares value and patronage through a Fuzz client. The patronage is recorded on the blockchain. The patron's history is portable. The author receives value. The cost of switching is zero.
+An author shares his work, his authorship. A patron shares value, patronage back through a Fuzz client. The patronage is recorded on the blockchain. The patron's history is portable. The author receives value. The cost of switching is zero.
 
 The protocol does not dictate which economy works. It provides infrastructure for value to flow back to creators, with proof, and lets the market decide the rest.
 

--- a/_posts/2025-12-12-fuzz.md
+++ b/_posts/2025-12-12-fuzz.md
@@ -30,23 +30,21 @@ The current system creates value by restricting ideas. We need a system where va
 
 Three players: an author, a patron, and a Fuzz client.
 
-An author publishes his work, his authorship. The authorship event includes a Bitcoin address for receiving value. Anyone can pay directly, though most patrons will interact through a Fuzz client.
+An author publishes his work, his authorship. The authorship event includes a Bitcoin address for receiving value. Anyone can pay the author directly, though most patrons will interact through a Fuzz client.
 
 A patron sends value, his patronage. He experiences the work and wants to contribute to the author. But why contribute if the work is already free?
 
-A Fuzz client lets patrons discover and experience works, and builds an economy around that experience: subscriptions, advertisements, pay-what-you-want, or any model the client invents. The protocol does not dictate the economy; it sets the rules.
+A Fuzz client lets patrons discover and experience works, and builds an economy around that experience: subscriptions, advertisements, pay-what-you-want, or any model the client invents. The protocol sets the rules, not the economy.
 
 When value flows through the Fuzz client to the author, it is attributed to the patron, who builds a patronage history that lives outside any client's control, portable, verifiable.
 
-Fuzz changes the incentives.
-
-An author can see his top patrons. He can reward them with early access, exclusive works, or recognition.
+Fuzz changes the incentives. An author can see his top patrons, and reward them with early access, exclusive works, or recognition.
 
 A patron who values his patronage history uses a Fuzz client that sends more to authors. If the client keeps too much, it diminishes the recorded patronage, and since the patron can verify how much each client passes through, he leaves for a better one.
 
 A client that sends little to authors loses patrons to one that sends more. The cost of switching is zero, patrons take their history with them, and clients compete on what they pass through.
 
-An author receives value from patrons regardless of which Fuzz client they use, he does not depend on any single client, and his audience is not locked in.
+An author receives value from patrons regardless of which Fuzz client they use. He depends on no single client, and his audience is not locked in.
 
 Each player acts on his own incentive. The better the work, the more patrons. The better the Fuzz client's economy, the more patrons. Patrons who contribute more rank higher with authors. Everyone checks everyone, and trust is minimized.[3]
 
@@ -138,13 +136,13 @@ The author then publishes a Nostr event with:
 - Metadata (title, description)
 - An address for receiving value
 
-The `url` tag is a retrieval hint; clients SHOULD fall back to the author's BUD-03 user-server-list (`kind:10063`) if the URL is unreachable, verifying retrieved bytes against the `x` tag SHA-256 hash.
+The `url` tag is a retrieval hint. If the URL is unreachable, clients SHOULD fall back to the author's BUD-03 user-server-list (`kind:10063`) and verify retrieved bytes against the `x` tag SHA-256 hash.
 
 The authorship event is a Nostr event living on relays, the work itself is stored on Blossom. Events on relays can be queried by kind, discovered through social graphs, and indexed by any Nostr client. Nostr events enable discovery. Fuzz clients solve curation.
 
 The author can self-host on his own machine, use a third-party Blossom server, or run several for redundancy, the choice is his. He does not depend on any Fuzz client to host his work.
 
-A Fuzz client can mirror works through Blossom's mirroring protocol, which adds redundancy and improves performance. If the original server goes down, the mirrored copy remains accessible, the hash guarantees integrity, the work is the same whichever server delivers it.
+A Fuzz client can mirror works through Blossom's mirroring protocol, which adds redundancy and improves performance. If the original server goes down, the mirrored copy remains accessible. The hash guarantees integrity, and the work is the same whichever server delivers it.
 
 A note on identity. The protocol requires a public key for each author, so if someone creates a work without a Nostr identity, another party can publish the authorship event on his behalf and list his address. The term "author" means whoever publishes the event and controls the address.
 

--- a/_posts/2025-12-12-fuzz.md
+++ b/_posts/2025-12-12-fuzz.md
@@ -8,7 +8,7 @@ date: 2025-12-12
 
 ## Abstract
 
-We propose a permissionless patronage protocol. A publisher shares a work and a public address. A subscriber contributes to the publisher through a distributor. The contribution is recorded and can be verified in a trust-minimized way. The cost for both the subscriber and the publisher to switch between distributors is zero.
+We propose a permissionless patronage protocol. An author publishes and shares a work and authorship. A patron publishes and shares value and patronage through a Fuzz client. The patronage is recorded and can be verified in a trust-minimized way. The cost for both the patron and the author to switch between Fuzz clients is zero.
 
 ---
 
@@ -28,166 +28,166 @@ The current system creates value by restricting ideas. We need a system where va
 
 ## Solution
 
-Three players: publisher, distributor, subscriber.
+Three players: an author, a patron, and a Fuzz client.
 
-A publisher creates something and shares it freely. The publisher includes an address where value can be sent. Anyone can send value directly. But most subscribers will interact through a distributor.
+An author publishes and shares a work and authorship. The author includes an address where value can be sent. Anyone can send value directly. But most patrons will interact through a Fuzz client.
 
-A subscriber experiences the work. The subscriber is willing to contribute to the publisher. But why contribute if the work is already free?
+A patron publishes and shares value and patronage. The patron experiences the work and is willing to support the author. But why support if the work is already free?
 
-A distributor is the portal the subscriber uses to discover and experience works. The distributor creates an economy around the experience. This can be subscriptions, advertisements, pay-what-you-want, or any model the distributor invents. The protocol does not dictate the economy, it only creates the rules, and then, the market finds what works.
+A Fuzz client lets patrons discover and experience works. The Fuzz client creates an economy around the experience. This can be subscriptions, advertisements, pay-what-you-want, or any model the Fuzz client invents. The protocol does not dictate the economy, it only creates the rules, and then, the market finds what works.
 
-When value flows through the distributor to the publisher, it is attributed to the subscriber. The subscriber builds a contribution history that lives outside any distributor's control. The history is portable and verifiable.
+When value flows through the Fuzz client to the author, it is attributed to the patron. The patron builds a patronage history that lives outside any Fuzz client's control. The history is portable and verifiable.
 
 Fuzz changes the incentives.
 
-A publisher can see their top contributors. The publisher can reward top contributors with early access, exclusive works, or recognition. This makes contribution history valuable to subscribers.
+An author can see their top patrons. The author can reward top patrons with early access, exclusive works, or recognition. This makes patronage history valuable to patrons.
 
-A subscriber who values their contribution history uses a distributor that sends more to publishers. A distributor that keeps too much diminishes the subscriber's recorded contributions. Since the subscriber can verify how much each distributor passes through, they choose to leave for a better distributor.
+A patron who values their patronage history uses a Fuzz client that sends more to authors. A Fuzz client that keeps too much diminishes the patron's recorded patronage. Since the patron can verify how much each Fuzz client passes through, they choose to leave for a better Fuzz client.
 
-A distributor that sends little to publishers loses subscribers to one that sends more. The cost of switching is zero, subscribers take their history with them, and good services compete on value, not on lock-in.
+A Fuzz client that sends little to authors loses patrons to one that sends more. The cost of switching is zero, patrons take their history with them, and good services compete on value, not on lock-in.
 
-A publisher receives value from subscribers regardless of which distributor they use. The publisher does not depend on any single distributor. The publisher's audience is not locked in.
+An author receives value from patrons regardless of which Fuzz client they use. The author does not depend on any single Fuzz client. The author's audience is not locked in.
 
-Each player does what benefits them. The better the work, the more subscribers. The better the distributor's economy, the more subscribers. And subscribers who contribute more rank higher with publishers. Everyone checks everyone. Trust requirements are minimized.[3]
+Each player does what benefits them. The better the work, the more patrons. The better the Fuzz client's economy, the more patrons. And patrons who contribute more rank higher with authors. Everyone checks everyone. Trust requirements are minimized.[3]
 
 ---
 
 ## The Mechanism
 
-### What is a Distributor
+### What is a Fuzz Client
 
-A distributor is the interface between publishers and subscribers. More concretely, it is a Nostr client that connects to relays, fetches publication events, displays works to subscribers, and publishes contribution events. A distributor also runs an economy, curates works, and provides discovery.
+A Fuzz client connects authors and patrons. More concretely, it is a Nostr client that connects to relays, fetches authorship events, displays works to patrons, and publishes patronage events. A Fuzz client also runs an economy, curates works, and provides discovery.
 
-From the publisher's perspective, the distributor is a dashboard. The publisher uploads works, organizes them, and tracks how they perform. The publisher creates a publication event, a Nostr event containing the work's hash, a URL to retrieve it, metadata, and an address for receiving value.
+A Fuzz client lets authors upload works, organize them, and track how they perform. The author publishes an authorship event, a Nostr event containing the work's hash, a URL to retrieve it, metadata, and an address for receiving value.
 
-From the subscriber's perspective, the distributor is a portal. The subscriber browses, searches, follows publishers, and experiences works. When value flows to a publisher, the distributor creates a contribution event, a Nostr event recording the subscriber, the publisher, and the amount.
+A Fuzz client lets patrons browse, search, follow authors, and experience works. When value flows to an author, the Fuzz client publishes a patronage event, a Nostr event recording the patron, the author, and the amount.
 
-A distributor connects several components:
+A Fuzz client connects several components:
 
-**Relay connection.** Publication events and contribution events flow through Nostr relays.
+**Relay connection.** Authorship events and patronage events flow through Nostr relays.
 
-**Work storage.** Works are stored on Blossom servers, addressed by hash. The publisher can self-host or use third-party servers. The distributor can mirror works for redundancy.
+**Work storage.** Works are stored on Blossom servers, addressed by hash. The author can self-host or use third-party servers. The Fuzz client can mirror works for redundancy.
 
-**Client interface.** The application that publishers and subscribers interact with. Web app, mobile app, desktop app, or any interface.
+**Client interface.** The application that authors and patrons interact with. Web app, mobile app, desktop app, or any interface.
 
-**Curation.** Distributors select, organize, recommend, and exclude. Different communities have different standards.
+**Curation.** Fuzz clients select, organize, recommend, and exclude. Different communities have different standards.
 
-**Economy.** The distributor runs an economy. This is how value flows from subscribers to publishers:
+**Economy.** The Fuzz client runs an economy. This is how value flows from patrons to authors:
 
-- Subscriptions split among publishers based on engagement
-- Attention converted to value and attributed to the subscriber
-- Pay-what-you-want where subscribers choose amounts
+- Subscriptions split among authors based on engagement
+- Attention converted to value and attributed to the patron
+- Pay-what-you-want where patrons choose amounts
 - Pay-per-piece where each work has a price
 - Any combination or innovation
 
 The protocol does not prefer one economy over another. It creates the rules. The market finds what works.
 
-A minimal distributor connects to public relays, proxies works from publisher servers, and publishes contribution events. A full-featured distributor runs its own relay, hosts works on its own Blossom server, and builds sophisticated economy models.
+A minimal Fuzz client connects to public relays, proxies works from author servers, and publishes patronage events. A full-featured Fuzz client runs its own relay, hosts works on its own Blossom server, and builds sophisticated economy models.
 
-A distributor can specialize. Some distributors might only serve publishers, a dashboard for creating publication events. Some might only serve subscribers, a portal for discovery and contribution. The contribution event is agnostic of the work; it centers on the publisher, not the publication.
+A Fuzz client can specialize. Some Fuzz clients might only serve authors, supporting the publishing of authorship events. Some might only serve patrons, supporting discovery and patronage. The patronage event is agnostic of the work; it centers on the author, not the work.
 
-### Proof of Contribution
+### Proof of Patronage
 
-The core primitive is simple: a Bitcoin transaction where the OP_RETURN contains the subscriber's Nostr public key.
+The core primitive is simple: a Bitcoin transaction where the OP_RETURN contains the patron's Nostr public key.
 
 **The transaction:**
 ```
-Output 1: Payment to publisher's Bitcoin address
-OP_RETURN: FUZZ<subscriber's 32-byte Nostr pubkey>
+Output 1: Payment to author's Bitcoin address
+OP_RETURN: FUZZ<patron's 32-byte Nostr pubkey>
 ```
 
-The prefix "FUZZ" (4 bytes) identifies the protocol. The subscriber's raw public key (32 bytes) identifies the contributor. Total: 36 bytes.
+The prefix "FUZZ" (4 bytes) identifies the protocol. The patron's raw public key (32 bytes) identifies who gets credit for the patronage. Total: 36 bytes.
 
-The publisher's address is already the recipient. The subscriber's pubkey in the OP_RETURN answers the question: who gets credit for this contribution?
+The author's address is already the recipient. The patron's pubkey in the OP_RETURN answers the question: who gets credit for this patronage?
 
-The transaction can come from any wallet. The source address does not matter. What matters is the OP_RETURN. This decouples the payment source from the attribution. A distributor can generate value through any economy and attribute it to subscribers.
+The transaction can come from any wallet. The source address does not matter. What matters is the OP_RETURN. This decouples the payment source from the attribution. A Fuzz client can generate value through any economy and attribute it to patrons.
 
-The distributor manages the economy. The blockchain records the contribution. The subscriber owns the proof.
+The Fuzz client manages the economy. The blockchain records the patronage. The patron owns the proof.
 
-**Publisher verification:**
+**Author verification:**
 ```
-1. Query blockchain: all transactions to publisher's address
+1. Query blockchain: all transactions to author's address
 2. For each transaction with OP_RETURN starting with "FUZZ":
    - Parse the 32-byte pubkey
-   - Record: { subscriber_pubkey, amount, timestamp }
+   - Record: { patron_pubkey, amount, timestamp }
 3. Aggregate by pubkey
-4. Result: ranked list of contributors
+4. Result: ranked list of patrons
 ```
 
 Anyone can run this query. The data is public. The proof is the chain.
 
-**Subscriber verification:**
+**Patron verification:**
 
-When a publisher offers access to top contributors, the subscriber proves they own the pubkey. Any Nostr event signed by that pubkey proves ownership. The blockchain proves contribution. Two public systems. One proves identity. One proves contribution.
+When an author offers access to top patrons, the patron proves they own the pubkey. Any Nostr event signed by that pubkey proves ownership. The blockchain proves patronage. Two public systems. One proves identity. One proves patronage.
 
 ### Limitations
 
 On-chain transactions are expensive for small amounts. If the transaction fee exceeds the contribution itself, the economics break. This limits the protocol to contributions above a certain threshold.
 
-Cheaper approaches exist. Lightning reduces costs dramatically.[4] Batching multiple subscribers into one transaction would reduce costs. These optimizations require additional infrastructure and design work that are outside the scope of this proposal.
+Cheaper approaches exist. Lightning reduces costs dramatically.[4] Batching multiple patrons into one transaction would reduce costs. These optimizations require additional infrastructure and design work that are outside the scope of this proposal.
 
 This document specifies on-chain settlement as the primitive. Future iterations can build on this foundation.
 
 ### Media Distribution
 
-Publishers upload their work to a Blossom server. Blossom is a protocol for storing binary data addressed by SHA-256 hash. The publisher receives a URL containing the hash. This hash is permanent. Anyone with the hash can retrieve the work from any Blossom server that has it.
+Authors upload their work to a Blossom server. Blossom is a protocol for storing binary data addressed by SHA-256 hash. The author receives a URL containing the hash. This hash is permanent. Anyone with the hash can retrieve the work from any Blossom server that has it.
 
-The publisher then creates a Nostr event with:
+The author then publishes a Nostr event with:
 - The hash of the work
 - A URL to retrieve it
 - Metadata (title, description, type)
 - An address for receiving value
 
-The publication is a Nostr event. The work is stored on Blossom. The publication lives on relays. This distinction matters: publications on relays can be queried by kind, discovered through social graphs, and indexed by any client. Nostr events enable discovery. Distributors solve curation.
+The authorship event is a Nostr event. The work is stored on Blossom. The authorship event lives on relays. This distinction matters: authorship events on relays can be queried by kind, discovered through social graphs, and indexed by any client. Nostr events enable discovery. Fuzz clients solve curation.
 
-The publisher can self-host their Blossom server on their own machine. The publisher can use a third-party Blossom server. The publisher can use multiple servers for redundancy. The choice is theirs. The publisher does not depend on any distributor to host their work.
+The author can self-host their Blossom server on their own machine. The author can use a third-party Blossom server. The author can use multiple servers for redundancy. The choice is theirs. The author does not depend on any Fuzz client to host their work.
 
-A distributor can mirror works using Blossom's mirroring protocol. This creates redundancy and improves performance. If the original server becomes unavailable, the mirrored copy remains accessible. The hash ensures integrity. The work is the same regardless of which server delivers it.
+A Fuzz client can mirror works using Blossom's mirroring protocol. This creates redundancy and improves performance. If the original server becomes unavailable, the mirrored copy remains accessible. The hash ensures integrity. The work is the same regardless of which server delivers it.
 
-A note on publisher identity: This protocol requires a public key for each publisher. If someone creates a work but has no Nostr identity, another party could publish on their behalf and list their address. The term "publisher" refers to whoever publishes the event and controls the address.
+A note on author identity: This protocol requires a public key for each author. If someone creates a work but has no Nostr identity, another party could publish the authorship event on their behalf and list their address. The term "author" refers to whoever publishes the authorship event and controls the address.
 
-The protocol assumes publishers share works without restriction. A publisher who publishes is declaring their work can be freely shared, copied, and distributed.
+The protocol assumes authors share works without restriction. An author who publishes an authorship event is declaring their work can be freely shared, copied, and distributed.
 
 ---
 
 ## Portability
 
-### Subscriber Switching
+### Patron Switching
 
-A subscriber's value is their contribution history. This history must not be locked in a distributor's database.
+A patron's value is their patronage history. This history must not be locked in a Fuzz client's database.
 
-Contributions are recorded on the blockchain. Any client can query for transactions to a publisher's address and parse the OP_RETURN for subscriber pubkeys. The subscriber's history is the aggregation of these transactions across all distributors.
+Patronage is recorded on the blockchain. Any client can query for transactions to an author's address and parse the OP_RETURN for patron pubkeys. The patron's history is the aggregation of these transactions across all Fuzz clients.
 
-When a subscriber switches distributors:
+When a patron switches Fuzz clients:
 1. Their identity (keypair) is theirs
 2. Their history is on the blockchain
-3. The new distributor can query for existing history
+3. The new Fuzz client can query for existing history
 4. There is nothing to export or migrate
 
-A distributor cannot lock in a subscriber's history because the distributor does not control the blockchain. Transactions are permanent. The proof persists.
+A Fuzz client cannot lock in a patron's history because the Fuzz client does not control the blockchain. Transactions are permanent. The proof persists.
 
-The cost of switching distributors is zero.
+The cost of switching Fuzz clients is zero.
 
-### Publisher Independence
+### Author Independence
 
-A publisher's work should not depend on any single distributor.
+An author's work should not depend on any single Fuzz client.
 
-The work itself is stored on Blossom servers. The publisher can run their own server on their own machine. The publisher can use multiple servers. The hash-based addressing means the work is retrievable from any server that has it.
+The work itself is stored on Blossom servers. The author can run their own server on their own machine. The author can use multiple servers. The hash-based addressing means the work is retrievable from any server that has it.
 
-The publisher's address for receiving value is theirs. It is not controlled by any distributor. Subscribers can send value directly if they choose.
+The author's address for receiving value is theirs. It is not controlled by any Fuzz client. Patrons can send value directly if they choose.
 
-The publisher's events are on relays. Any distributor can read them. The publisher is not exclusive to any distributor.
+The author's events are on relays. Any Fuzz client can read them. The author is not exclusive to any Fuzz client.
 
 ---
 
 ## Events
 
-### Publication Event (Kind 31339)
+### Authorship Event (Kind 31339)
 
 ```json
 {
   "kind": 31339,
-  "pubkey": "<publisher pubkey>",
+  "pubkey": "<author pubkey>",
   "created_at": 1234567890,
   "content": "<description>",
   "tags": [
@@ -200,31 +200,31 @@ The publisher's events are on relays. Any distributor can read them. The publish
 }
 ```
 
-The `address` tag contains the publisher's Bitcoin address for receiving contributions.
+The `address` tag contains the author's Bitcoin address for receiving patronage.
 
 Kind 31339 is an addressable event. The `d` tag makes it addressable and updatable.
 
-### Contribution Event (Kind 32500)
+### Patronage Event (Kind 32500)
 
 ```json
 {
   "kind": 32500,
-  "pubkey": "<distributor pubkey>",
+  "pubkey": "<Fuzz client pubkey>",
   "created_at": 1234567890,
   "content": "",
   "tags": [
     ["d", "<txid>"],
-    ["p", "<publisher pubkey>"],
-    ["s", "<subscriber pubkey>"],
+    ["p", "<author pubkey>"],
+    ["c", "<patron pubkey>"],
     ["amount", "<satoshis>"],
     ["txid", "<bitcoin transaction id>"]
   ]
 }
 ```
 
-The `s` tag denotes the subscriber.
+The `c` tag denotes the patron.
 
-This event is optional. The blockchain is the source of truth. This event provides convenience: it helps clients discover contributions without querying the blockchain directly. The txid allows verification.
+This event is optional. The blockchain is the source of truth. This event provides convenience: it helps clients discover patronage without querying the blockchain directly. The txid allows verification.
 
 ---
 
@@ -232,7 +232,7 @@ This event is optional. The blockchain is the source of truth. This event provid
 
 **Nostr.**[5] Protocol for decentralized social networks. Events, relays, signatures. Addressable events use the `d` tag. Fuzz builds on this foundation.
 
-**Blossom.**[6] Media storage addressed by SHA-256 hash. Publishers use Blossom for storing works. Distributors can mirror for redundancy.
+**Blossom.**[6] Media storage addressed by SHA-256 hash. Authors use Blossom for storing works. Fuzz clients can mirror for redundancy.
 
 **Bitcoin.**[7] OP_RETURN is a script opcode for embedding data in transactions. Fuzz uses 36 bytes (4-byte prefix + 32-byte pubkey).
 
@@ -240,7 +240,7 @@ This event is optional. The blockchain is the source of truth. This event provid
 
 ## Conclusion
 
-A publisher creates a work and shares it freely. A subscriber contributes to the publisher through a distributor. The contribution is recorded on the blockchain. The subscriber's history is portable. The publisher receives value. The cost of switching is zero.
+An author publishes and shares a work and authorship. A patron publishes and shares value and patronage through a Fuzz client. The patronage is recorded on the blockchain. The patron's history is portable. The author receives value. The cost of switching is zero.
 
 The protocol does not dictate which economy works. It provides infrastructure for value to flow back to creators, with proof, and lets the market decide the rest.
 

--- a/_posts/2025-12-12-fuzz.md
+++ b/_posts/2025-12-12-fuzz.md
@@ -8,7 +8,7 @@ date: 2025-12-12
 
 ## Abstract
 
-We propose a permissionless patronage protocol. An author publishes his work, his authorship. A patron publishes value, his patronage, back through a Fuzz client. The patronage is recorded and can be verified in a trust-minimized way. The cost for both the patron and the author to switch between Fuzz clients is zero.
+We propose a permissionless patronage protocol. An author publishes his work, his authorship. A patron sends value, his patronage, back through a Fuzz client. The patronage is recorded and can be verified in a trust-minimized way. The cost for both the patron and the author to switch between Fuzz clients is zero.
 
 ---
 
@@ -30,9 +30,9 @@ The current system creates value by restricting ideas. We need a system where va
 
 Three players: an author, a patron, and a Fuzz client.
 
-An author publishes his work, his authorship. The authorship event includes an address where value can be sent. Anyone can send value directly, though most patrons will interact through a Fuzz client.
+An author publishes his work, his authorship. The authorship event includes a Bitcoin address for receiving value. Anyone can pay directly, though most patrons will interact through a Fuzz client.
 
-A patron publishes value, his patronage. He experiences the work and wants to patronize the author. But why patronize if the work is already free?
+A patron sends value, his patronage. He experiences the work and wants to contribute to the author. But why contribute if the work is already free?
 
 A Fuzz client lets patrons discover and experience works, and builds an economy around that experience: subscriptions, advertisements, pay-what-you-want, or any model the client invents. The protocol does not dictate the economy; it sets the rules.
 
@@ -40,7 +40,7 @@ When value flows through the Fuzz client to the author, it is attributed to the 
 
 Fuzz changes the incentives.
 
-An author can see his top patrons. He can reward them with early access, exclusive works, or recognition. Patronage history becomes valuable.
+An author can see his top patrons. He can reward them with early access, exclusive works, or recognition.
 
 A patron who values his patronage history uses a Fuzz client that sends more to authors. If the client keeps too much, it diminishes the recorded patronage, and since the patron can verify how much each client passes through, he leaves for a better one.
 
@@ -48,7 +48,7 @@ A client that sends little to authors loses patrons to one that sends more. The 
 
 An author receives value from patrons regardless of which Fuzz client they use, he does not depend on any single client, and his audience is not locked in.
 
-Each player acts on his own incentive. The better the work, the more patrons. The better the Fuzz client's economy, the more patrons. Patrons who patronize more rank higher with authors. Everyone checks everyone, and trust is minimized.[3]
+Each player acts on his own incentive. The better the work, the more patrons. The better the Fuzz client's economy, the more patrons. Patrons who contribute more rank higher with authors. Everyone checks everyone, and trust is minimized.[3]
 
 ---
 
@@ -56,7 +56,7 @@ Each player acts on his own incentive. The better the work, the more patrons. Th
 
 ### What is a Fuzz Client
 
-A Fuzz client connects authors and patrons, or more precisely it is a Nostr client that connects to relays, fetches authorship events, displays works to patrons, and may publish patronage events. It also runs an economy, curates works, and provides discovery.
+A Fuzz client connects authors and patrons. Concretely, it is a Nostr client that connects to relays, fetches authorship events, displays works to patrons, and may publish patronage events. It also runs an economy, curates works, and provides discovery.
 
 Fuzz clients let authors upload works, organize them, and track how they perform. The author publishes an authorship event, a Nostr event containing the work's hash, a URL to retrieve it, metadata, and an address for receiving value.
 
@@ -68,7 +68,7 @@ The Fuzz client connects several components:
 
 **Work storage.** Works are stored on Blossom servers, addressed by hash. The author can self-host or use third-party servers. The Fuzz client can mirror works for redundancy.
 
-**Client interface.** The application that authors and patrons interact with. Web app, mobile app, desktop app, or any interface.
+**Client interface.** The application authors and patrons interact with, on the web, on a phone, on a desktop, on whatever surface fits.
 
 **Curation.** Fuzz clients select, organize, and exclude according to whatever standard their community holds.
 
@@ -80,7 +80,7 @@ The Fuzz client connects several components:
 - Pay-per-piece where each work has a price
 - Any mix the client invents
 
-The protocol does not prefer one economy over another. It creates the rules. The market finds what works.
+The protocol does not prefer one economy over another. It creates the rules and lets clients compete.
 
 A minimal Fuzz client connects to public relays, proxies works from author servers, and publishes patronage events. A full-featured one runs its own relay, hosts works on its own Blossom server, and builds sophisticated economy models.
 
@@ -122,9 +122,9 @@ When an author offers access to top patrons, the patron proves he owns the pubke
 
 ### Limitations
 
-On-chain transactions are expensive for small amounts, if the fee exceeds the patronage the economics break, which limits the protocol to patronage above some floor.
+On-chain transactions are expensive for small amounts. If the fee exceeds the contribution, the economics break, and the protocol is limited to contributions above some floor.
 
-Cheaper approaches exist. Lightning settles small payments off-chain at negligible cost.[4] Batching multiple patrons into one transaction reduces fees further. Both want infrastructure and design that fall outside this proposal.
+Cheaper approaches exist. Lightning settles small payments off-chain at negligible cost.[4] Batching multiple patrons into one transaction reduces fees further. Both require infrastructure and design that fall outside this proposal.
 
 This document specifies on-chain settlement as the primitive. Future iterations can build on this foundation.
 
@@ -156,7 +156,7 @@ The protocol assumes authors share their work freely. Publishing an authorship e
 
 ### Patron Switching
 
-A patron's stake is his patronage history, which must not be locked inside any Fuzz client's database.
+A patron's patronage history must not be locked inside any Fuzz client's database.
 
 Patronage is recorded on the blockchain, and anyone can query an author's address and parse the OP_RETURN for patron pubkeys. The patron's history is the aggregation across all Fuzz clients.
 
@@ -243,7 +243,7 @@ This event is optional. The blockchain is the source of truth. The event provide
 
 ## Conclusion
 
-An author publishes his work, his authorship. A patron publishes value, his patronage, back through a Fuzz client. The patronage is recorded on the blockchain, the patron's history is portable, the author receives value, the cost of switching is zero.
+An author publishes his work, his authorship. A patron sends value, his patronage, back through a Fuzz client. The patronage is recorded on the blockchain, the patron's history is portable, the author receives value, the cost of switching is zero.
 
 The protocol does not dictate which economy works. It provides infrastructure for value to flow back to authors, with proof, and leaves the rest to whatever the communities settle on.
 


### PR DESCRIPTION
Rename publisher/subscriber/distributor to author/patron/Fuzz client. Plus event names (Authorship Event, Patronage Event), primitive (Proof of Patronage), distributor-precision pass, L99 doubling fix, and JSON tag s → c.